### PR TITLE
Allow push to any gem host

### DIFF
--- a/chloride.gemspec
+++ b/chloride.gemspec
@@ -14,15 +14,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/puppetlabs/chloride'
   spec.license       = 'Apache-2.0'
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against ' \
-      'public gem pushes.'
-  end
-
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
Prior to this commit the default skeleton gemspec had a default
restriction on which host we can publish the gem to.
This commit removes that restriction so we can publish to rubygems
and the internal mirror.