### PR TITLE
Continue porting functionality from the Installer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -163,7 +163,10 @@ Style/Documentation:
     - 'lib/chloride/errors.rb'
     - 'lib/chloride/event.rb'
     - 'lib/chloride/event/message.rb'
+    - 'lib/chloride/executor.rb'
     - 'lib/chloride/host.rb'
+    - 'lib/chloride/step.rb'
+    - 'lib/chloride/step/noop.rb'
 
 # Cop supports --auto-correct.
 Style/EmptyLines:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,11 +50,13 @@ Lint/Void:
 
 # Offense count: 6
 Metrics/AbcSize:
+  Enabled: false
   Max: 70
 
 # Offense count: 4
 # Configuration parameters: CountComments.
 Metrics/BlockLength:
+  Enabled: false
   Max: 45
 
 # Offense count: 1
@@ -64,6 +66,7 @@ Metrics/ClassLength:
 
 # Offense count: 2
 Metrics/CyclomaticComplexity:
+  Enabled: false
   Max: 20
 
 # Offense count: 90
@@ -75,10 +78,12 @@ Metrics/LineLength:
 # Offense count: 10
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
+  Enabled: false
   Max: 89
 
 # Offense count: 2
 Metrics/PerceivedComplexity:
+  Enabled: false
   Max: 23
 
 # Offense count: 10
@@ -119,6 +124,7 @@ Style/BracesAroundHashParameters:
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: nested, compact
 Style/ClassAndModuleChildren:
+  Enabled: false
   Exclude:
     - 'lib/chloride/action/execute.rb'
     - 'lib/chloride/action/file_copy.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,6 +59,9 @@ Metrics/BlockLength:
   Enabled: false
   Max: 45
 
+Metrics/BlockNesting:
+  Max: 4
+
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:

--- a/lib/chloride/action/detect_platform.rb
+++ b/lib/chloride/action/detect_platform.rb
@@ -1,0 +1,246 @@
+require 'chloride/errors'
+require 'chloride/action'
+
+# Executes a shell command on the hosts provided. Will block until completion.
+class Chloride::Action::DetectPlatform < Chloride::Action
+  attr_reader :results, :hosts
+
+  # TODO: Document args
+  def initialize(args)
+    super
+
+    @hosts = args[:hosts] || [args[:host]]
+  end
+
+
+  # TODO: Document block format
+  def go(&stream_block)
+    @status = :running
+    @results = Hash.new {|h,k| h[k] = {}}
+    @hosts.each do |host|
+      # First try identifying using lsb_release.  This takes care of Ubuntu (lsb-release is part of ubuntu-minimal).
+      lsb = exec_and_log(host, "lsb_release -icr", true, @results[host.hostname], &stream_block)
+
+      if lsb[:exit_status] == 0
+        lsb_data = {}
+        lsb[:stdout].each_line do |l|
+          k, v = l.split(':')
+          if k && v
+            lsb_data[k.strip] = v.strip
+          end
+        end
+
+        distribution = lsb_data['Distributor ID'].downcase.gsub(/\s+/, "")
+        distribution = case distribution
+        when /redhatenterpriseserver|redhatenterpriseclient|redhatenterpriseas|redhatenterprisees|enterpriseenterpriseserver|redhatenterpriseworkstation|redhatenterprisecomputenode|oracleserver/
+          :rhel
+        when /enterprise.*/
+          :centos
+        when /scientific|scientifics|scientificsl/
+          :rhel
+        when /amazonami/
+          :amazon
+        when /suselinux/
+          :sles
+        else
+          distribution.to_sym
+        end
+
+        release = lsb_data['Release'].gsub(/\s+/, "")
+        release = case distribution
+        when :centos, :rhel
+          release.split('.')[0]
+        when :debian
+          if release == 'testing'
+            '7'
+          else
+            release.split('.')[0]
+          end
+        else
+          release
+        end
+      end
+
+      # Check for Redhat
+      if !distribution && !release
+        redhat_release = exec_and_log(host, "cat /etc/redhat-release", true, @results[host.hostname], &stream_block)
+
+        if redhat_release[:exit_status] == 0
+          stdout = redhat_release[:stdout]
+
+          distribution = case stdout
+          when /red hat enterprise/im
+            :rhel
+          when /centos/im
+            :centos
+          when /scientific/im
+            :rhel
+          end
+
+          release = /.* release ([[:digit:]]).*/.match(stdout)[1]
+        end
+      end
+
+      # Check for Cumulus
+      if !distribution && !release
+        os_release = exec_and_log(host, "cat /etc/os-release", true, @results[host.hostname], &stream_block)
+
+        if os_release[:exit_status] == 0
+          stdout = os_release[:stdout]
+
+          if /Cumulus Linux/m.match(stdout)
+            distribution = :cumulus
+          end
+          if distribution
+            release = /VERSION_ID=(\d+\.\d)/.match(stdout)[1]
+          end
+        end
+      end
+
+      # Check for EOS
+      if !distribution && !release
+        eos_release = exec_and_log(host, "cat /etc/Eos-release", true, @results[host.hostname], &stream_block)
+
+        if eos_release[:exit_status] == 0
+          stdout = eos_release[:stdout]
+
+          if /Arista Networks EOS/m.match(stdout)
+            distribution = :eos
+          end
+
+          release = /^Arista Networks EOS v*(.*)\..*$/.match(stdout)[1]
+        end
+      end
+
+      # Check for Debian
+      if !distribution && !release
+        debian_version = exec_and_log(host, "cat /etc/debian_version", true, @results[host.hostname], &stream_block)
+
+        if debian_version[:exit_status] == 0
+          stdout = debian_version[:stdout]
+          distribution = :debian
+
+          release = case stdout
+          when /^[[:digit:]]/
+            stdout.split('.')[0]
+          when /^wheezy/.match(stdout)
+            "7"
+          end
+        end
+      end
+
+      # Check for SuSE
+      if !distribution && !release
+        suse_release = exec_and_log(host, "cat /etc/SuSE-release", true, @results[host.hostname], &stream_block)
+
+        if suse_release[:exit_status] == 0
+          stdout = suse_release[:stdout]
+
+          if /Enterprise Server/.match(stdout)
+            distribution = :sles
+            release = /^VERSION = (\d*)/m.match(stdout)[1]
+          end
+        end
+      end
+
+      # Check for Amazon 6, or fail
+      if !distribution && !release
+        system_release = exec_and_log(host, "cat /etc/system-release", true, @results[host.hostname], &stream_block)
+
+        if system_release[:exit_status] == 0
+          stdout = system_release[:stdout]
+
+          if /amazon linux/im.match(stdout)
+            distribution = :amazon
+            # How is this safe to assume?
+            release = "6"
+          end
+        end
+      end
+
+      # Check for Solaris
+      if !distribution && !release
+        uname = exec_and_log(host, "uname -s", true, @results[host.hostname], &stream_block)
+
+        if uname[:exit_status] == 0
+          distribution = case uname.results[hostname][:stdout].strip
+          when "SunOS"
+            unamer = exec_and_log(host, "uname -r", true, @results[host.hostname], &stream_block)
+
+            if unamer[:exit_status] == 0
+              release = unamer.results[hostname][:stdout].split('.')[0]
+            end
+
+            :solaris
+          when "AIX"
+            oslevel = exec_and_log(host, "oslevel", true, @results[host.hostname], &stream_block)
+            yield oslevel
+
+            if oslevel[:exit_status] == 0
+              release = oslevel.results[hostname][:stdout].split('.')[0..1].join('.')
+            end
+
+            :aix
+          end
+        end
+      end
+
+      # Architecture
+      unamem = exec_and_log(host, "uname -m", true, @results[host.hostname], &stream_block)
+
+      if unamem[:exit_status] == 0
+        architecture = unamem[:stdout].strip
+
+        architecture = case architecture
+        when 'i686'
+          'i386'
+        when 'ppc'
+          'powerpc'
+        when 'x86_64'
+          [:ubuntu, :debian].include?(distribution) ? 'amd64' : 'x86_64'
+        else
+          architecture
+        end
+      end
+
+      host.data[:os] = {}
+      # Tag
+      @results[host.hostname][:distribution] = host.data[:os][:distribution] = distribution
+      @results[host.hostname][:release] = host.data[:os][:release] = release
+      @results[host.hostname][:architecture] = host.data[:os][:architecture] = architecture
+
+      tag_distribution = distribution || 'unknown'
+      tag_release = release || 'unknown'
+      tag_architecture = architecture || 'unknown'
+
+      @results[host.hostname][:tag] = host.data[:os][:tag] = case distribution
+      when :rhel, :centos, :amazon
+        "el-#{tag_release}-#{tag_architecture}"
+      else
+        "#{tag_distribution}-#{tag_release}-#{tag_architecture}"
+      end
+    end
+
+    @results
+  end
+
+  def success?
+    @results.all? do |host, result|
+      !(result[:distribution].nil? || result[:release].nil? || result[:architecture].nil?)
+    end
+  end
+
+  def error_message(hostname)
+    if @results.has_key?(hostname) && @results[hostname].has_key?(:stderr)
+      @results[hostname][:stderr].strip
+    end
+  end
+
+  def name
+    :detect_platform
+  end
+
+  def description
+    "Detect OS on #{@hosts.join(', ')}"
+  end
+end

--- a/lib/chloride/action/detect_platform.rb
+++ b/lib/chloride/action/detect_platform.rb
@@ -12,69 +12,66 @@ class Chloride::Action::DetectPlatform < Chloride::Action
     @hosts = args[:hosts] || [args[:host]]
   end
 
-
   # TODO: Document block format
   def go(&stream_block)
     @status = :running
-    @results = Hash.new {|h,k| h[k] = {}}
+    @results = Hash.new { |h, k| h[k] = {} }
     @hosts.each do |host|
       # First try identifying using lsb_release.  This takes care of Ubuntu (lsb-release is part of ubuntu-minimal).
-      lsb = exec_and_log(host, "lsb_release -icr", true, @results[host.hostname], &stream_block)
+      lsb = exec_and_log(host, 'lsb_release -icr', true, @results[host.hostname], &stream_block)
 
-      if lsb[:exit_status] == 0
+      if (lsb[:exit_status]).zero?
         lsb_data = {}
         lsb[:stdout].each_line do |l|
           k, v = l.split(':')
-          if k && v
-            lsb_data[k.strip] = v.strip
-          end
+          lsb_data[k.strip] = v.strip if k && v
         end
 
-        distribution = lsb_data['Distributor ID'].downcase.gsub(/\s+/, "")
+        distribution = lsb_data['Distributor ID'].downcase.gsub(/\s+/, '')
         distribution = case distribution
-        when /redhatenterpriseserver|redhatenterpriseclient|redhatenterpriseas|redhatenterprisees|enterpriseenterpriseserver|redhatenterpriseworkstation|redhatenterprisecomputenode|oracleserver/
-          :rhel
-        when /enterprise.*/
-          :centos
-        when /scientific|scientifics|scientificsl/
-          :rhel
-        when /amazonami/
-          :amazon
-        when /suselinux/
-          :sles
-        else
-          distribution.to_sym
+                       when /redhatenterpriseserver|redhatenterpriseclient|redhatenterpriseas|redhatenterprisees|enterpriseenterpriseserver|redhatenterpriseworkstation|redhatenterprisecomputenode|oracleserver/
+                         :rhel
+                       when /enterprise.*/
+                         :centos
+                       when /scientific|scientifics|scientificsl/
+                         :rhel
+                       when /amazonami/
+                         :amazon
+                       when /suselinux/
+                         :sles
+                       else
+                         distribution.to_sym
         end
 
-        release = lsb_data['Release'].gsub(/\s+/, "")
+        release = lsb_data['Release'].gsub(/\s+/, '')
         release = case distribution
-        when :centos, :rhel
-          release.split('.')[0]
-        when :debian
-          if release == 'testing'
-            '7'
-          else
-            release.split('.')[0]
-          end
-        else
-          release
+                  when :centos, :rhel
+                    release.split('.')[0]
+                  when :debian
+                    if release == 'testing'
+                      '7'
+                    else
+                      release.split('.')[0]
+                    end
+                  else
+                    release
         end
       end
 
       # Check for Redhat
       if !distribution && !release
-        redhat_release = exec_and_log(host, "cat /etc/redhat-release", true, @results[host.hostname], &stream_block)
+        redhat_release = exec_and_log(host, 'cat /etc/redhat-release', true, @results[host.hostname], &stream_block)
 
-        if redhat_release[:exit_status] == 0
+        if (redhat_release[:exit_status]).zero?
           stdout = redhat_release[:stdout]
 
           distribution = case stdout
-          when /red hat enterprise/im
-            :rhel
-          when /centos/im
-            :centos
-          when /scientific/im
-            :rhel
+                         when /red hat enterprise/im
+                           :rhel
+                         when /centos/im
+                           :centos
+                         when /scientific/im
+                           :rhel
           end
 
           release = /.* release ([[:digit:]]).*/.match(stdout)[1]
@@ -83,30 +80,24 @@ class Chloride::Action::DetectPlatform < Chloride::Action
 
       # Check for Cumulus
       if !distribution && !release
-        os_release = exec_and_log(host, "cat /etc/os-release", true, @results[host.hostname], &stream_block)
+        os_release = exec_and_log(host, 'cat /etc/os-release', true, @results[host.hostname], &stream_block)
 
-        if os_release[:exit_status] == 0
+        if (os_release[:exit_status]).zero?
           stdout = os_release[:stdout]
 
-          if /Cumulus Linux/m.match(stdout)
-            distribution = :cumulus
-          end
-          if distribution
-            release = /VERSION_ID=(\d+\.\d)/.match(stdout)[1]
-          end
+          distribution = :cumulus if /Cumulus Linux/m.match(stdout)
+          release = /VERSION_ID=(\d+\.\d)/.match(stdout)[1] if distribution
         end
       end
 
       # Check for EOS
       if !distribution && !release
-        eos_release = exec_and_log(host, "cat /etc/Eos-release", true, @results[host.hostname], &stream_block)
+        eos_release = exec_and_log(host, 'cat /etc/Eos-release', true, @results[host.hostname], &stream_block)
 
-        if eos_release[:exit_status] == 0
+        if (eos_release[:exit_status]).zero?
           stdout = eos_release[:stdout]
 
-          if /Arista Networks EOS/m.match(stdout)
-            distribution = :eos
-          end
+          distribution = :eos if /Arista Networks EOS/m.match(stdout)
 
           release = /^Arista Networks EOS v*(.*)\..*$/.match(stdout)[1]
         end
@@ -114,26 +105,26 @@ class Chloride::Action::DetectPlatform < Chloride::Action
 
       # Check for Debian
       if !distribution && !release
-        debian_version = exec_and_log(host, "cat /etc/debian_version", true, @results[host.hostname], &stream_block)
+        debian_version = exec_and_log(host, 'cat /etc/debian_version', true, @results[host.hostname], &stream_block)
 
-        if debian_version[:exit_status] == 0
+        if (debian_version[:exit_status]).zero?
           stdout = debian_version[:stdout]
           distribution = :debian
 
           release = case stdout
-          when /^[[:digit:]]/
-            stdout.split('.')[0]
-          when /^wheezy/.match(stdout)
-            "7"
+                    when /^[[:digit:]]/
+                      stdout.split('.')[0]
+                    when /^wheezy/.match(stdout)
+                      '7'
           end
         end
       end
 
       # Check for SuSE
       if !distribution && !release
-        suse_release = exec_and_log(host, "cat /etc/SuSE-release", true, @results[host.hostname], &stream_block)
+        suse_release = exec_and_log(host, 'cat /etc/SuSE-release', true, @results[host.hostname], &stream_block)
 
-        if suse_release[:exit_status] == 0
+        if (suse_release[:exit_status]).zero?
           stdout = suse_release[:stdout]
 
           if /Enterprise Server/.match(stdout)
@@ -145,61 +136,61 @@ class Chloride::Action::DetectPlatform < Chloride::Action
 
       # Check for Amazon 6, or fail
       if !distribution && !release
-        system_release = exec_and_log(host, "cat /etc/system-release", true, @results[host.hostname], &stream_block)
+        system_release = exec_and_log(host, 'cat /etc/system-release', true, @results[host.hostname], &stream_block)
 
-        if system_release[:exit_status] == 0
+        if (system_release[:exit_status]).zero?
           stdout = system_release[:stdout]
 
           if /amazon linux/im.match(stdout)
             distribution = :amazon
             # How is this safe to assume?
-            release = "6"
+            release = '6'
           end
         end
       end
 
       # Check for Solaris
       if !distribution && !release
-        uname = exec_and_log(host, "uname -s", true, @results[host.hostname], &stream_block)
+        uname = exec_and_log(host, 'uname -s', true, @results[host.hostname], &stream_block)
 
-        if uname[:exit_status] == 0
+        if (uname[:exit_status]).zero?
           distribution = case uname.results[hostname][:stdout].strip
-          when "SunOS"
-            unamer = exec_and_log(host, "uname -r", true, @results[host.hostname], &stream_block)
+                         when 'SunOS'
+                           unamer = exec_and_log(host, 'uname -r', true, @results[host.hostname], &stream_block)
 
-            if unamer[:exit_status] == 0
-              release = unamer.results[hostname][:stdout].split('.')[0]
-            end
+                           if (unamer[:exit_status]).zero?
+                             release = unamer.results[hostname][:stdout].split('.')[0]
+                           end
 
-            :solaris
-          when "AIX"
-            oslevel = exec_and_log(host, "oslevel", true, @results[host.hostname], &stream_block)
-            yield oslevel
+                           :solaris
+                         when 'AIX'
+                           oslevel = exec_and_log(host, 'oslevel', true, @results[host.hostname], &stream_block)
+                           yield oslevel
 
-            if oslevel[:exit_status] == 0
-              release = oslevel.results[hostname][:stdout].split('.')[0..1].join('.')
-            end
+                           if (oslevel[:exit_status]).zero?
+                             release = oslevel.results[hostname][:stdout].split('.')[0..1].join('.')
+                           end
 
-            :aix
+                           :aix
           end
         end
       end
 
       # Architecture
-      unamem = exec_and_log(host, "uname -m", true, @results[host.hostname], &stream_block)
+      unamem = exec_and_log(host, 'uname -m', true, @results[host.hostname], &stream_block)
 
-      if unamem[:exit_status] == 0
+      if (unamem[:exit_status]).zero?
         architecture = unamem[:stdout].strip
 
         architecture = case architecture
-        when 'i686'
-          'i386'
-        when 'ppc'
-          'powerpc'
-        when 'x86_64'
-          [:ubuntu, :debian].include?(distribution) ? 'amd64' : 'x86_64'
-        else
-          architecture
+                       when 'i686'
+                         'i386'
+                       when 'ppc'
+                         'powerpc'
+                       when 'x86_64'
+                         [:ubuntu, :debian].include?(distribution) ? 'amd64' : 'x86_64'
+                       else
+                         architecture
         end
       end
 
@@ -214,10 +205,10 @@ class Chloride::Action::DetectPlatform < Chloride::Action
       tag_architecture = architecture || 'unknown'
 
       @results[host.hostname][:tag] = host.data[:os][:tag] = case distribution
-      when :rhel, :centos, :amazon
-        "el-#{tag_release}-#{tag_architecture}"
-      else
-        "#{tag_distribution}-#{tag_release}-#{tag_architecture}"
+                                                             when :rhel, :centos, :amazon
+                                                               "el-#{tag_release}-#{tag_architecture}"
+                                                             else
+                                                               "#{tag_distribution}-#{tag_release}-#{tag_architecture}"
       end
     end
 
@@ -231,7 +222,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
   end
 
   def error_message(hostname)
-    if @results.has_key?(hostname) && @results[hostname].has_key?(:stderr)
+    if @results.key?(hostname) && @results[hostname].key?(:stderr)
       @results[hostname][:stderr].strip
     end
   end

--- a/lib/chloride/action/detect_platform.rb
+++ b/lib/chloride/action/detect_platform.rb
@@ -41,7 +41,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
                          :sles
                        else
                          distribution.to_sym
-        end
+                       end
 
         release = lsb_data['Release'].gsub(/\s+/, '')
         release = case distribution
@@ -55,7 +55,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
                     end
                   else
                     release
-        end
+                  end
       end
 
       # Check for Redhat
@@ -72,7 +72,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
                            :centos
                          when /scientific/im
                            :rhel
-          end
+                         end
 
           release = /.* release ([[:digit:]]).*/.match(stdout)[1]
         end
@@ -85,7 +85,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
         if (os_release[:exit_status]).zero?
           stdout = os_release[:stdout]
 
-          distribution = :cumulus if /Cumulus Linux/m.match(stdout)
+          distribution = :cumulus if /Cumulus Linux/m =~ stdout
           release = /VERSION_ID=(\d+\.\d)/.match(stdout)[1] if distribution
         end
       end
@@ -97,7 +97,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
         if (eos_release[:exit_status]).zero?
           stdout = eos_release[:stdout]
 
-          distribution = :eos if /Arista Networks EOS/m.match(stdout)
+          distribution = :eos if /Arista Networks EOS/m =~ stdout
 
           release = /^Arista Networks EOS v*(.*)\..*$/.match(stdout)[1]
         end
@@ -116,7 +116,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
                       stdout.split('.')[0]
                     when /^wheezy/.match(stdout)
                       '7'
-          end
+                    end
         end
       end
 
@@ -127,7 +127,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
         if (suse_release[:exit_status]).zero?
           stdout = suse_release[:stdout]
 
-          if /Enterprise Server/.match(stdout)
+          if /Enterprise Server/ =~ stdout
             distribution = :sles
             release = /^VERSION = (\d*)/m.match(stdout)[1]
           end
@@ -141,7 +141,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
         if (system_release[:exit_status]).zero?
           stdout = system_release[:stdout]
 
-          if /amazon linux/im.match(stdout)
+          if /amazon linux/im =~ stdout
             distribution = :amazon
             # How is this safe to assume?
             release = '6'
@@ -172,7 +172,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
                            end
 
                            :aix
-          end
+                         end
         end
       end
 
@@ -191,7 +191,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
                          [:ubuntu, :debian].include?(distribution) ? 'amd64' : 'x86_64'
                        else
                          architecture
-        end
+                       end
       end
 
       host.data[:os] = {}
@@ -209,22 +209,20 @@ class Chloride::Action::DetectPlatform < Chloride::Action
                                                                "el-#{tag_release}-#{tag_architecture}"
                                                              else
                                                                "#{tag_distribution}-#{tag_release}-#{tag_architecture}"
-      end
+                                                             end
     end
 
     @results
   end
 
   def success?
-    @results.all? do |host, result|
+    @results.all? do |_host, result|
       !(result[:distribution].nil? || result[:release].nil? || result[:architecture].nil?)
     end
   end
 
   def error_message(hostname)
-    if @results.key?(hostname) && @results[hostname].key?(:stderr)
-      @results[hostname][:stderr].strip
-    end
+    @results[hostname][:stderr].strip if @results.key?(hostname) && @results[hostname].key?(:stderr)
   end
 
   def name

--- a/lib/chloride/event/message.rb
+++ b/lib/chloride/event/message.rb
@@ -1,4 +1,4 @@
-require 'uri'
+require 'cgi'
 
 module Chloride
   class Event
@@ -15,7 +15,7 @@ module Chloride
         {
           severity: @severity,
           hostname: @hostname,
-          message: URI.escape(remove_ansi(@message))
+          message: CGI.escape_html(remove_ansi(@message))
         }.to_json(*args)
       end
 

--- a/lib/chloride/executor.rb
+++ b/lib/chloride/executor.rb
@@ -4,7 +4,7 @@ class Chloride::Executor
     @stream_block = stream_block
   end
 
-  def publish(event, action_id=nil)
+  def publish(event, action_id = nil)
     event.action_id = action_id if action_id
     @stream_block.call(event) if @stream_block
   end
@@ -37,7 +37,7 @@ class Chloride::Executor
             publish(Chloride::Event.new(:action_fail, action.name), action_id)
           end
         end
-      rescue Exception => e
+      rescue Exception => e # rubocop:disable Lint/RescueException
         # Treat *any* error like a step failure and proceed accordingly
         @logger.error [e, *e.backtrace].join("\n")
         step.error(step.infra.installer_hostname, "An error occured while performing #{step.name}: #{e.message}")

--- a/lib/chloride/executor.rb
+++ b/lib/chloride/executor.rb
@@ -1,0 +1,67 @@
+class Chloride::Executor
+  def initialize(logger, &stream_block)
+    @logger = logger
+    @stream_block = stream_block
+  end
+
+  def publish(event, action_id=nil)
+    event.action_id = action_id if action_id
+    @stream_block.call(event) if @stream_block
+  end
+
+  def execute(steps)
+    # Perform the plan given
+    skip_remaining_steps = false
+
+    steps.each do |step|
+      # TODO: Check for step.pre
+      if skip_remaining_steps
+        publish Chloride::Event.new(:step_skip, step.name)
+        next
+      end
+
+      publish Chloride::Event.new(:step_start, step.name)
+
+      begin
+        step.perform_step do |action|
+          action_id = SecureRandom.uuid
+          publish(Chloride::Event.new(:action_start, action.name), action_id)
+
+          action.go do |event|
+            publish(event, action_id)
+          end
+
+          if action.success?
+            publish(Chloride::Event.new(:action_success, action.name), action_id)
+          else
+            publish(Chloride::Event.new(:action_fail, action.name), action_id)
+          end
+        end
+      rescue Exception => e
+        # Treat *any* error like a step failure and proceed accordingly
+        @logger.error [e, *e.backtrace].join("\n")
+        step.error(step.infra.installer_hostname, "An error occured while performing #{step.name}: #{e.message}")
+      end
+
+      type = case step.status
+             when :error
+               skip_remaining_steps = step.fail_stop?
+               :step_error
+             when :warn
+               :step_warn
+             else
+               :step_success
+             end
+
+      Chloride::Event.new(type, step.name).tap do |event|
+        step.messages.each { |m| event.add_message(m) }
+        publish event
+      end
+
+      # Clear the messages so that revalidation doesn't log them again
+      step.reset
+
+      # TODO: Check for step.post
+    end
+  end
+end

--- a/lib/chloride/host.rb
+++ b/lib/chloride/host.rb
@@ -7,7 +7,7 @@ require 'timeout'
 require 'json'
 
 class Chloride::Host
-  attr_reader :data, :remote_conn, :roles, :hostname, :username, :ssh_key_file, :ssh_key_passphrase, :alt_names, :localhost
+  attr_reader :data, :remote_conn, :hostname, :username, :ssh_key_file, :ssh_key_passphrase, :localhost
   attr_accessor :data
 
   def initialize(hostname, config = {})

--- a/lib/chloride/step.rb
+++ b/lib/chloride/step.rb
@@ -1,7 +1,7 @@
 class Chloride::Step
   attr_reader :actions, :hosts, :messages, :status
 
-  def initialize(data={}, pre=nil, post=nil)
+  def initialize(data = {}, pre = nil, post = nil)
     @pre = pre
     @post = post
     @data = data
@@ -14,16 +14,16 @@ class Chloride::Step
     @uuid = SecureRandom.uuid
   end
 
-  def perform_step(&execute)
+  def perform_step(_execute_block)
     raise NotImplementedError, "Don't know how to perform this kind of step"
   end
 
   def name
-    raise NotImplementedError, "Step name required"
+    raise NotImplementedError, 'Step name required'
   end
 
   def description
-    raise NotImplementedError, "Step description required"
+    raise NotImplementedError, 'Step description required'
   end
 
   def fail_stop?

--- a/lib/chloride/step.rb
+++ b/lib/chloride/step.rb
@@ -1,0 +1,53 @@
+class Chloride::Step
+  attr_reader :actions, :hosts, :messages, :status
+
+  def initialize(data={}, pre=nil, post=nil)
+    @pre = pre
+    @post = post
+    @data = data
+    @hosts = Set.new
+
+    @actions = []
+    @messages = []
+
+    @status = :success
+    @uuid = SecureRandom.uuid
+  end
+
+  def perform_step(&execute)
+    raise NotImplementedError, "Don't know how to perform this kind of step"
+  end
+
+  def name
+    raise NotImplementedError, "Step name required"
+  end
+
+  def description
+    raise NotImplementedError, "Step description required"
+  end
+
+  def fail_stop?
+    false
+  end
+
+  def reset
+    @status = :success
+    @messages.clear
+  end
+
+  def error(hostname, message)
+    @messages << Chloride::Event::Message.new(:error, hostname, message)
+    @status = :error
+  end
+
+  def warning(hostname, message)
+    @messages << Chloride::Event::Message.new(:warn, hostname, message)
+    @status = :warn unless @status == :error
+  end
+
+  def info(hostname, message)
+    @messages << Chloride::Event::Message.new(:info, hostname, message)
+  end
+end
+
+require 'chloride/event'

--- a/lib/chloride/step/noop.rb
+++ b/lib/chloride/step/noop.rb
@@ -1,0 +1,26 @@
+require 'chloride/step'
+
+class Chloride::Step::Noop < Chloride::Step
+  def initialize(data={}, pre=nil, post=nil)
+    super(data, pre, post)
+    @name = data[:name]
+    @performed = false
+  end
+
+  def perform_step(&stream_block)
+    @performed = true
+    # noop
+  end
+
+  def performed?
+    @performed
+  end
+
+  def name
+    @name
+  end
+
+  def description
+    "Do basically nothing"
+  end
+end

--- a/lib/chloride/step/noop.rb
+++ b/lib/chloride/step/noop.rb
@@ -1,13 +1,13 @@
 require 'chloride/step'
 
 class Chloride::Step::Noop < Chloride::Step
-  def initialize(data={}, pre=nil, post=nil)
+  def initialize(data = {}, pre = nil, post = nil)
     super(data, pre, post)
     @name = data[:name]
     @performed = false
   end
 
-  def perform_step(&stream_block)
+  def perform_step(_execute_block)
     @performed = true
     # noop
   end
@@ -16,11 +16,9 @@ class Chloride::Step::Noop < Chloride::Step
     @performed
   end
 
-  def name
-    @name
-  end
+  attr_reader :name
 
   def description
-    "Do basically nothing"
+    'Do basically nothing'
   end
 end

--- a/spec/lib/chloride/executor.rb
+++ b/spec/lib/chloride/executor.rb
@@ -4,7 +4,7 @@ require 'chloride/executor'
 describe Chloride::Executor do
   subject { described_class.new(Logger.new('/dev/null')) }
 
-  describe "#execute" do
+  describe '#execute' do
     let(:executed_events) do
       collected_events = []
       executor = described_class.new(Logger.new('/dev/null')) { |e| collected_events << e }
@@ -13,23 +13,23 @@ describe Chloride::Executor do
     end
 
     let(:step1) do
-      Chloride::Step::Noop.new(:name => :step1, :r18n => R18n.t)
+      Chloride::Step::Noop.new(name: :step1)
     end
 
     let(:step2) do
-      Chloride::Step::Noop.new(:name => :step2, :r18n => R18n.t)
+      Chloride::Step::Noop.new(name: :step2)
     end
 
     let(:steps) { [step1, step2] }
 
-    it "performs each step" do
+    it 'performs each step' do
       subject.execute(steps)
 
       expect(step1).to be_performed
       expect(step2).to be_performed
     end
 
-    it "sends a step_start event before each step" do
+    it 'sends a step_start event before each step' do
       allow(subject).to receive(:publish)
       expect(subject).to receive(:publish).with(satisfy { |e| e.type == :step_start && e.name == :step1 }).ordered
       expect(step1).to receive(:perform_step).ordered
@@ -40,44 +40,44 @@ describe Chloride::Executor do
     end
 
     shared_examples_for :step_failure do
-      it "sends a step_error event" do
+      it 'sends a step_error event' do
         expect(executed_events).to include satisfy { |m| m.type == :step_error && m.name == :step1 }
       end
 
-      it "does not send a step_success event" do
+      it 'does not send a step_success event' do
         expect(executed_events).not_to include satisfy { |m| m.type == :step_success && m.name == :step1 }
       end
 
-      it "does not send a step_warn event" do
+      it 'does not send a step_warn event' do
         expect(executed_events).not_to include satisfy { |m| m.type == :step_warn && m.name == :step1 }
       end
 
-      it "executes the remaining steps if the failed step is not fail-stop" do
+      it 'executes the remaining steps if the failed step is not fail-stop' do
         subject.execute(steps)
 
         expect(step2).to be_performed
       end
 
-      describe "when the step is fail-stop" do
+      describe 'when the step is fail-stop' do
         before :each do
           allow(step1).to receive(:fail_stop?).and_return(true)
         end
 
-        it "does not perform the remaining steps" do
+        it 'does not perform the remaining steps' do
           subject.execute(steps)
 
           expect(step2).not_to be_performed
         end
 
-        it "sends a step_skip event for the remaining steps" do
+        it 'sends a step_skip event for the remaining steps' do
           expect(executed_events).to include satisfy { |m| m.type == :step_skip && m.name == :step2 }
         end
 
-        it "does not send a step_start event for the remaining steps" do
+        it 'does not send a step_start event for the remaining steps' do
           expect(executed_events).not_to include satisfy { |m| m.type == :step_start && m.name == :step2 }
         end
 
-        it "does not send any complete event for the remaining steps" do
+        it 'does not send any complete event for the remaining steps' do
           expect(executed_events).not_to include satisfy { |m| m.type == :step_success && m.name == :step2 }
           expect(executed_events).not_to include satisfy { |m| m.type == :step_warn && m.name == :step2 }
           expect(executed_events).not_to include satisfy { |m| m.type == :step_error && m.name == :step2 }
@@ -85,9 +85,9 @@ describe Chloride::Executor do
       end
     end
 
-    describe "when a step has status error" do
+    describe 'when a step has status error' do
       before :each do
-        step1.error("localhost", "OH NO")
+        step1.error('localhost', 'OH NO')
       end
 
       it_behaves_like :step_failure
@@ -96,10 +96,10 @@ describe Chloride::Executor do
     [Chloride::RemoteError, RuntimeError, Timeout::Error].each do |error|
       describe "when a step raises #{error}" do
         before :each do
-          allow(step1).to receive(:perform_step).and_raise(error, "Something has gone terribly, horribly awry!")
+          allow(step1).to receive(:perform_step).and_raise(error, 'Something has gone terribly, horribly awry!')
         end
 
-        it "adds the exception as an error message" do
+        it 'adds the exception as an error message' do
           event = executed_events.find { |m| m.type == :step_error && m.name == :step1 }
           expect(event.messages).to include satisfy { |m| m.severity == :error && m.message =~ /An error occured while performing.*terribly, horribly awry!/ }
         end
@@ -108,56 +108,56 @@ describe Chloride::Executor do
       end
     end
 
-    describe "when a step has status warn" do
+    describe 'when a step has status warn' do
       before :each do
-        step1.warning("localhost", "oh no")
+        step1.warning('localhost', 'oh no')
       end
 
-      it "sends a step_warn event" do
+      it 'sends a step_warn event' do
         expect(executed_events).to include satisfy { |m| m.type == :step_warn && m.name == :step1 }
       end
 
-      it "does not send a step_success event" do
+      it 'does not send a step_success event' do
         expect(executed_events).not_to include satisfy { |m| m.type == :step_success && m.name == :step1 }
       end
 
-      it "does not send a step_error event" do
+      it 'does not send a step_error event' do
         expect(executed_events).not_to include satisfy { |m| m.type == :step_error && m.name == :step1 }
       end
 
-      it "executes the remaining steps if the step is not fail-stop" do
+      it 'executes the remaining steps if the step is not fail-stop' do
         subject.execute(steps)
 
         expect(step2).to be_performed
       end
 
-      it "executes the remaining steps if the step is fail-stop" do
+      it 'executes the remaining steps if the step is fail-stop' do
         subject.execute(steps)
 
         expect(step2).to be_performed
       end
     end
 
-    describe "when a step has status success" do
-      it "sends a step_success event" do
+    describe 'when a step has status success' do
+      it 'sends a step_success event' do
         expect(executed_events).to include satisfy { |m| m.type == :step_success && m.name == :step1 }
       end
 
-      it "does not send a step_error event" do
+      it 'does not send a step_error event' do
         expect(executed_events).not_to include satisfy { |m| m.type == :step_error && m.name == :step1 }
       end
 
-      it "does not send a step_warn event" do
+      it 'does not send a step_warn event' do
         expect(executed_events).not_to include satisfy { |m| m.type == :step_warn && m.name == :step1 }
       end
 
-      it "executes the remaining steps if the step is not fail-stop" do
+      it 'executes the remaining steps if the step is not fail-stop' do
         subject.execute(steps)
 
         expect(step2).to be_performed
       end
 
-      it "executes the remaining steps if the step is fail-stop" do
+      it 'executes the remaining steps if the step is fail-stop' do
         subject.execute(steps)
 
         expect(step2).to be_performed
@@ -165,15 +165,15 @@ describe Chloride::Executor do
     end
 
     it "includes the step's messages on its completed event" do
-      step1.info("localhost", "AW YEAH")
+      step1.info('localhost', 'AW YEAH')
 
       event = executed_events.find { |m| m.type == :step_success && m.name == :step1 }
 
-      expect(event.messages.map(&:message)).to eq ["AW YEAH"]
+      expect(event.messages.map(&:message)).to eq ['AW YEAH']
     end
 
-    it "resets the step when completed" do
-      step1.error("localhost", "OH NO")
+    it 'resets the step when completed' do
+      step1.error('localhost', 'OH NO')
 
       subject.execute(steps)
 

--- a/spec/lib/chloride/executor.rb
+++ b/spec/lib/chloride/executor.rb
@@ -1,0 +1,184 @@
+require 'spec_helper'
+require 'chloride/executor'
+
+describe Chloride::Executor do
+  subject { described_class.new(Logger.new('/dev/null')) }
+
+  describe "#execute" do
+    let(:executed_events) do
+      collected_events = []
+      executor = described_class.new(Logger.new('/dev/null')) { |e| collected_events << e }
+      executor.execute(steps)
+      collected_events
+    end
+
+    let(:step1) do
+      Chloride::Step::Noop.new(:name => :step1, :r18n => R18n.t)
+    end
+
+    let(:step2) do
+      Chloride::Step::Noop.new(:name => :step2, :r18n => R18n.t)
+    end
+
+    let(:steps) { [step1, step2] }
+
+    it "performs each step" do
+      subject.execute(steps)
+
+      expect(step1).to be_performed
+      expect(step2).to be_performed
+    end
+
+    it "sends a step_start event before each step" do
+      allow(subject).to receive(:publish)
+      expect(subject).to receive(:publish).with(satisfy { |e| e.type == :step_start && e.name == :step1 }).ordered
+      expect(step1).to receive(:perform_step).ordered
+      expect(subject).to receive(:publish).with(satisfy { |e| e.type == :step_start && e.name == :step2 }).ordered
+      expect(step2).to receive(:perform_step).ordered
+
+      subject.execute(steps)
+    end
+
+    shared_examples_for :step_failure do
+      it "sends a step_error event" do
+        expect(executed_events).to include satisfy { |m| m.type == :step_error && m.name == :step1 }
+      end
+
+      it "does not send a step_success event" do
+        expect(executed_events).not_to include satisfy { |m| m.type == :step_success && m.name == :step1 }
+      end
+
+      it "does not send a step_warn event" do
+        expect(executed_events).not_to include satisfy { |m| m.type == :step_warn && m.name == :step1 }
+      end
+
+      it "executes the remaining steps if the failed step is not fail-stop" do
+        subject.execute(steps)
+
+        expect(step2).to be_performed
+      end
+
+      describe "when the step is fail-stop" do
+        before :each do
+          allow(step1).to receive(:fail_stop?).and_return(true)
+        end
+
+        it "does not perform the remaining steps" do
+          subject.execute(steps)
+
+          expect(step2).not_to be_performed
+        end
+
+        it "sends a step_skip event for the remaining steps" do
+          expect(executed_events).to include satisfy { |m| m.type == :step_skip && m.name == :step2 }
+        end
+
+        it "does not send a step_start event for the remaining steps" do
+          expect(executed_events).not_to include satisfy { |m| m.type == :step_start && m.name == :step2 }
+        end
+
+        it "does not send any complete event for the remaining steps" do
+          expect(executed_events).not_to include satisfy { |m| m.type == :step_success && m.name == :step2 }
+          expect(executed_events).not_to include satisfy { |m| m.type == :step_warn && m.name == :step2 }
+          expect(executed_events).not_to include satisfy { |m| m.type == :step_error && m.name == :step2 }
+        end
+      end
+    end
+
+    describe "when a step has status error" do
+      before :each do
+        step1.error("localhost", "OH NO")
+      end
+
+      it_behaves_like :step_failure
+    end
+
+    [Chloride::RemoteError, RuntimeError, Timeout::Error].each do |error|
+      describe "when a step raises #{error}" do
+        before :each do
+          allow(step1).to receive(:perform_step).and_raise(error, "Something has gone terribly, horribly awry!")
+        end
+
+        it "adds the exception as an error message" do
+          event = executed_events.find { |m| m.type == :step_error && m.name == :step1 }
+          expect(event.messages).to include satisfy { |m| m.severity == :error && m.message =~ /An error occured while performing.*terribly, horribly awry!/ }
+        end
+
+        it_behaves_like :step_failure
+      end
+    end
+
+    describe "when a step has status warn" do
+      before :each do
+        step1.warning("localhost", "oh no")
+      end
+
+      it "sends a step_warn event" do
+        expect(executed_events).to include satisfy { |m| m.type == :step_warn && m.name == :step1 }
+      end
+
+      it "does not send a step_success event" do
+        expect(executed_events).not_to include satisfy { |m| m.type == :step_success && m.name == :step1 }
+      end
+
+      it "does not send a step_error event" do
+        expect(executed_events).not_to include satisfy { |m| m.type == :step_error && m.name == :step1 }
+      end
+
+      it "executes the remaining steps if the step is not fail-stop" do
+        subject.execute(steps)
+
+        expect(step2).to be_performed
+      end
+
+      it "executes the remaining steps if the step is fail-stop" do
+        subject.execute(steps)
+
+        expect(step2).to be_performed
+      end
+    end
+
+    describe "when a step has status success" do
+      it "sends a step_success event" do
+        expect(executed_events).to include satisfy { |m| m.type == :step_success && m.name == :step1 }
+      end
+
+      it "does not send a step_error event" do
+        expect(executed_events).not_to include satisfy { |m| m.type == :step_error && m.name == :step1 }
+      end
+
+      it "does not send a step_warn event" do
+        expect(executed_events).not_to include satisfy { |m| m.type == :step_warn && m.name == :step1 }
+      end
+
+      it "executes the remaining steps if the step is not fail-stop" do
+        subject.execute(steps)
+
+        expect(step2).to be_performed
+      end
+
+      it "executes the remaining steps if the step is fail-stop" do
+        subject.execute(steps)
+
+        expect(step2).to be_performed
+      end
+    end
+
+    it "includes the step's messages on its completed event" do
+      step1.info("localhost", "AW YEAH")
+
+      event = executed_events.find { |m| m.type == :step_success && m.name == :step1 }
+
+      expect(event.messages.map(&:message)).to eq ["AW YEAH"]
+    end
+
+    it "resets the step when completed" do
+      step1.error("localhost", "OH NO")
+
+      subject.execute(steps)
+
+      expect(step1.messages).to be_empty
+      expect(step1.status).to eq(:success)
+    end
+  end
+end

--- a/spec/lib/chloride/step_spec.rb
+++ b/spec/lib/chloride/step_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'chloride/step'
+
+describe Chloride::Step do
+
+  subject { described_class.new() }
+
+  it "defaults to status success" do
+    expect(subject.status).to eq :success
+  end
+
+  it "has status success after receiving an info" do
+    subject.info('localhost', 'hi step')
+
+    expect(subject.status).to eq :success
+  end
+
+  it "has status warn after receiving a warning" do
+    subject.warning('localhost', 'oh no step')
+
+    expect(subject.status).to eq :warn
+  end
+
+  it "has status error after receiving an error" do
+    subject.error('localhost', 'OH NO STEP')
+
+    expect(subject.status).to eq :error
+  end
+
+  it "has status error after receiving a warning then an error" do
+    subject.warning('localhost', 'oh no step')
+    subject.error('localhost', 'OH NO STEP')
+
+    expect(subject.status).to eq :error
+  end
+
+  it "has status error after receiving an error then a warning" do
+    subject.error('localhost', 'OH NO STEP')
+    subject.warning('localhost', 'oh no step')
+
+    expect(subject.status).to eq :error
+  end
+end

--- a/spec/lib/chloride/step_spec.rb
+++ b/spec/lib/chloride/step_spec.rb
@@ -2,39 +2,38 @@ require 'spec_helper'
 require 'chloride/step'
 
 describe Chloride::Step do
+  subject { described_class.new }
 
-  subject { described_class.new() }
-
-  it "defaults to status success" do
+  it 'defaults to status success' do
     expect(subject.status).to eq :success
   end
 
-  it "has status success after receiving an info" do
+  it 'has status success after receiving an info' do
     subject.info('localhost', 'hi step')
 
     expect(subject.status).to eq :success
   end
 
-  it "has status warn after receiving a warning" do
+  it 'has status warn after receiving a warning' do
     subject.warning('localhost', 'oh no step')
 
     expect(subject.status).to eq :warn
   end
 
-  it "has status error after receiving an error" do
+  it 'has status error after receiving an error' do
     subject.error('localhost', 'OH NO STEP')
 
     expect(subject.status).to eq :error
   end
 
-  it "has status error after receiving a warning then an error" do
+  it 'has status error after receiving a warning then an error' do
     subject.warning('localhost', 'oh no step')
     subject.error('localhost', 'OH NO STEP')
 
     expect(subject.status).to eq :error
   end
 
-  it "has status error after receiving an error then a warning" do
+  it 'has status error after receiving an error then a warning' do
     subject.error('localhost', 'OH NO STEP')
     subject.warning('localhost', 'oh no step')
 


### PR DESCRIPTION
This PR ports over more functionality from the installer and fixes a few issues introduced during the port. Specifically: the Executor, Step, Noop Step, and detect_platform action have been ported over because those components are definitely re-usable outside of the Installer.