### PR TITLE
(maint) update go_execute help output

### DIFF
--- a/bin/go_execute
+++ b/bin/go_execute
@@ -5,7 +5,7 @@ require 'chloride'
 require 'optparse'
 
 opt_parse = OptionParser.new do |opts|
-  opts.banner = 'Usage: go_execute [options] hosts'
+  opts.banner = 'Usage: go_execute [options] host command'
   args = {}
 
   opts.on('-h', '--help', 'Prints this help') do


### PR DESCRIPTION
Prior to this commit the go_execute --help output implied it would handle multiple hosts and also didn't mention that you supply a command.
