### PR TITLE
Cleanup stdout/stderr polling

### DIFF
--- a/lib/chloride/host.rb
+++ b/lib/chloride/host.rb
@@ -176,17 +176,8 @@ class Chloride::Host
           info['thread_status'] = wait_thr.status
 
           begin
-            while out = stdout.gets
-              buffer_proc.call(info, :stdout, out)
-            end
-          rescue IO::WaitReadable => _blocking
-            buffer_proc.call(info, :stdout, "Waiting on #{cmd}...")
-          end
-
-          begin
-            while err = stderr.gets
-              buffer_proc.call(info, :stderr, err)
-            end
+            buffer_proc.call(info, :stdout, stdout.gets)
+            buffer_proc.call(info, :stderr, stderr.gets)
           rescue IO::WaitReadable => _blocking
             buffer_proc.call(info, :stderr, "Waiting on #{cmd}...")
           end


### PR DESCRIPTION
Prior to this commit we were using a while loop to query stdout/stderr
returned by a running process and we had two separate exception
handlers for any `WaitReadable` exceptions that occured.
This commit removes the while loops because from what I can tell
they are unnecessary, as well as consolidates the `WaitReadable`
rescue blocks to one area that will print that the process
is waiting to `stderr`.